### PR TITLE
Kan 4 requested feature show more than 10 results per page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ temp/
 # VS Code
 .vscode
 *.txt
+.DS_Store

--- a/spotdl/types/song.py
+++ b/spotdl/types/song.py
@@ -141,7 +141,7 @@ class Song:
         - The raw search results
         """
         spotify_client = SpotifyClient()
-        raw_search_results = spotify_client.search(search_term)
+        raw_search_results = spotify_client.search(search_term, limit=20)
 
         if raw_search_results is None:
             raise SongError(f"Spotipy error, no response: {search_term}")

--- a/tests/types/test_song.py
+++ b/tests/types/test_song.py
@@ -249,3 +249,24 @@ def test_song_from_dict():
     )
     assert song.explicit == False
     assert song.popularity == 0
+
+
+def test_search_returns_20_unique_songs(mocker):
+    # Mock the SpotifyClient's search method to return a controlled response
+    mocked_search = mocker.patch('spotdl.types.song.SpotifyClient.search')
+    mocked_search.return_value = {
+        "tracks": {
+            "items": [{"id": str(i)} for i in range(20)]  # Simulate 20 unique track IDs
+        }
+    }
+
+    # Perform the search
+    search_term = "test search term"
+    raw_search_results = Song.search(search_term)
+
+    # Assert that the list length is 20
+    assert len(raw_search_results["tracks"]["items"]) == 20
+
+    # Assert all values are unique
+    track_ids = [track["id"] for track in raw_search_results["tracks"]["items"]]
+    assert len(track_ids) == len(set(track_ids)), "Expected all track IDs to be unique"


### PR DESCRIPTION
# Title
Requested Feature - Show more than 10 results per page

## Description
User wanted the web-ui to show more than 10 results on the front end after performing a search. Added a parameter in the spotipy API search call to increases the gathered results to 20.

## Related Issue
https://github.com/spotDL/spotify-downloader/issues/1937

## How Has This Been Tested?
Created a test function to make sure 20 results are loaded that are all unique.

## Screenshots (if appropriate)
<img width="491" alt="Screenshot 2024-04-29 094017" src="https://github.com/jchacker5/spotify-downloader/assets/80708514/d37cdb0b-03b3-4fef-add7-2684760d6ab8">
<img width="562" alt="Screenshot 2024-04-29 093958" src="https://github.com/jchacker5/spotify-downloader/assets/80708514/07c463f3-5df4-49b4-bbf2-21002a9790f6">


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


